### PR TITLE
Modify `run_dft_opt` function to return hessian and frequencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
@@ -11,15 +11,15 @@ repos:
         additional_dependencies: [tomli]
         args: [--in-place, --config, ./pyproject.toml]
 -   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 25.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort
-    rev: 5.11.5
+    rev: 6.0.0
     hooks:
     -   id: isort
 -   repo: local
@@ -33,6 +33,6 @@ repos:
         pass_filenames: false
         always_run: true
 -   repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.362
+    rev: v1.1.393
     hooks:
     - id: pyright

--- a/cloudcompchem/controllers.py
+++ b/cloudcompchem/controllers.py
@@ -12,7 +12,7 @@ from cloudcompchem.exceptions import (
     MoleculeSpinAndChargeViolationError,
     NotLoggedInException,
 )
-from cloudcompchem.models import EnergyRequest, DFTOptRequest
+from cloudcompchem.models import DFTOptRequest, EnergyRequest
 from cloudcompchem.opt import run_dft_opt
 
 
@@ -157,7 +157,6 @@ class DFTController:
 
         return make_response(asdict(structure_dict), HTTPStatus.OK)
 
-
     def _parse_dft_request(self, request) -> EnergyRequest:
         """Parse the simulation request into the auth token, the protocols to
         simulation, and the model to use.
@@ -186,10 +185,10 @@ class DFTController:
         self._logger.info("Request constructed!")
 
         return dft_input
-    
+
     def _parse_opt_request(self, request) -> DFTOptRequest:
-        """Parse the geometry optimization request into the auth token, the protocols to
-        simulation, and the model to use.
+        """Parse the geometry optimization request into the auth token, the
+        protocols to simulation, and the model to use.
 
         Generally there should be no reason to update this function.
         """

--- a/cloudcompchem/models.py
+++ b/cloudcompchem/models.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, get_args
 
+from pyscf.hessian.rhf import Hessian
+
 from .exceptions import (
     DFTRequestValidationException,
     MoleculeSpinAndChargeViolationError,
@@ -295,13 +297,20 @@ class DFTOptRequest:
 class StructureRelaxationResponse:
     molecule: Molecule
     energy: float
-    converged: bool
+    converged: bool | object
     orbitals: list[Orbital]
+    hessian: Hessian
+    frequencies: dict
 
     @staticmethod
     def from_dict(d: dict) -> StructureRelaxationResponse:
         orbital_info = d["orbitals"]
         orbitals = [Orbital(**kwargs) for kwargs in orbital_info]
         return StructureRelaxationResponse(
-            orbitals=orbitals, converged=d["converged"], energy=d["energy"], molecule=d["molecule"]
+            orbitals=orbitals,
+            converged=d["converged"],
+            energy=d["energy"],
+            molecule=d["molecule"],
+            hessian=d["hessian"],
+            frequencies=d["frequencies"],
         )

--- a/cloudcompchem/opt.py
+++ b/cloudcompchem/opt.py
@@ -49,7 +49,7 @@ def run_dft_opt(dft_input: DFTOptRequest) -> StructureRelaxationResponse:
     # Frequency and Hessian calculation
     hessian_calculator = Hessian(calc)
     hessian_matrix = hessian_calculator.kernel()
-    frequencies = thermo.harmonic_analysis(mol, hess=hessian_calculator)
+    frequencies = thermo.harmonic_analysis(mol, hess=hessian_matrix)
 
     logger.info("Finished DFT optimization and frequency calculation!")
 


### PR DESCRIPTION
TODO:

- Add a function that corrects imaginary (negative frequencies)
- Add tests

@bruno-ecl As of now, I have added the functionality to the `run_dft_opt` function, would we rather have a separate function instead or do you think the way it is right now works?

I added to the `run_dft_opt` because the good practice in computational chemistry is to proceed with frequency calculations after you optimize the geometry, so I thought it would be nice to have it already embedded with geometry optimization, which does mean that I could not have it as a separate function tho. 😄 